### PR TITLE
add endpoints to fetch song names and playlist filenames

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,12 +4,16 @@ Copyright © 2024 NME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/matthew-c-atu/project-audio-streamer/pkg/connect"
 	"github.com/spf13/cobra"
@@ -35,7 +39,10 @@ var rootCmd = &cobra.Command{
 	// has an action associated with it:
 	Run: func(cmd *cobra.Command, args []string) {
 		root := &RootCfg{cmd}
+		// root.printFileNames()
+
 		root.serveHls()
+		// root.serveFileNames()
 	},
 }
 
@@ -50,8 +57,9 @@ func Execute() {
 
 func init() {
 	rootCmd.PersistentFlags().BoolP("toggle", "t", false, "Help message for toggle")
-	rootCmd.PersistentFlags().IntP("port", "p", 8080, "The port on which to host the server")
-	rootCmd.PersistentFlags().StringP("filepath", "f", "music", "path to the audio file")
+	rootCmd.PersistentFlags().IntP("hlsport", "p", 9001, "The port on which to host the HLS file server")
+	rootCmd.PersistentFlags().IntP("filenameport", "n", 9002, "The port on which to host the filename server")
+	rootCmd.PersistentFlags().StringP("filepath", "f", "music/hls", "path to the audio file")
 }
 
 func (r *RootCfg) serve() {
@@ -118,21 +126,119 @@ func (r *RootCfg) serve() {
 }
 
 func (r *RootCfg) serveHls() {
-	port, _ := r.Flags().GetInt("port")
+	port, _ := r.Flags().GetInt("hlsport")
 	filepath, _ := r.Flags().GetString("filepath")
 
 	// connPool := connect.NewConnectionPool()
 
-	log.Println("calling go stream...")
+	// log.Println("calling go stream...")
 	// go connect.Stream(connPool, contents, audioSettings)
 	// Array equal to sample rate * 1s
+	extension := ".m3u8"
+	dirPath, _ := r.Flags().GetString("filepath")
+	playlistFiles := findFilesWithExtension(dirPath, extension)
+
+	var songNames []string
+	for f := range playlistFiles {
+		songNames = append(songNames, strings.TrimSuffix(playlistFiles[f], extension))
+
+	}
+
+	marshaledPlaylistFiles, err := json.Marshal(playlistFiles)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	marshaledSongNames, err := json.Marshal(songNames)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	http.Handle("/", addHeaders(http.FileServer(http.Dir(filepath))))
 
-	slog.Info(fmt.Sprintf("Starting server on port %v\n", port))
+	songFilesEndpoint := "/songfiles"
+	songNamesEndpoint := "/songnames"
+	http.HandleFunc(songFilesEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(marshaledPlaylistFiles)
+	})
+
+	http.HandleFunc(songNamesEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(marshaledSongNames)
+	})
+	slog.Info(fmt.Sprintf("Starting fileserver on port %v\n", port))
 	slog.Info(fmt.Sprintf("Serving %s over HTTP on port %v\n", filepath, port))
+	slog.Info(fmt.Sprintf("Serving names of files with exentension %v in directory %v over HTTP on port %v%s\n", extension, dirPath, port, songFilesEndpoint))
+	slog.Info(fmt.Sprintf("Serving names of songs in directory %v over HTTP on port %v%s\n", dirPath, port, songNamesEndpoint))
 
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+}
+
+func (r *RootCfg) serveFileNames() {
+	extension := ".m3u8"
+	port, _ := r.Flags().GetInt("filenameport")
+	dirPath, _ := r.Flags().GetString("filepath")
+	playlistFiles := findFilesWithExtension(dirPath, extension)
+	marshaled, err := json.Marshal(playlistFiles)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	http.HandleFunc("/files", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(marshaled)
+	})
+
+	slog.Info(fmt.Sprintf("Starting fileserver on port %v\n", port))
+	slog.Info(fmt.Sprintf("Serving names of files with exentension %v in directory %v over HTTP on port %v\n", extension, dirPath, port))
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+
+}
+func (r *RootCfg) printFileNames() {
+	dirPath, _ := r.Flags().GetString("filepath")
+
+	// files, err := filepath.Glob(fmt.Sprintf("%v/*.m3u8", dirPath))
+	// files, err := os.ReadDir(dirPath)
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+	//
+	// for _, f := range files {
+	// 	fmt.Println(f)
+	// }
+	//
+	found := findFilesWithExtension(dirPath, ".m3u8")
+	for f := range found {
+		fmt.Println(found[f])
+	}
+
+	marshaled, err := json.Marshal(found)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s\n", marshaled)
+
+	var unmarshaled []string
+	err = json.Unmarshal(marshaled, &unmarshaled)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for f := range unmarshaled {
+		println(unmarshaled[f])
+	}
+}
+
+func findFilesWithExtension(root, extension string) []string {
+	var found []string
+	filepath.WalkDir(root, func(s string, d fs.DirEntry, e error) error {
+		if e != nil {
+			return e
+		}
+		if filepath.Ext(d.Name()) == extension {
+			found = append(found, d.Name())
+		}
+		return nil
+	})
+	return found
 }
 
 func addHeaders(h http.Handler) http.HandlerFunc {


### PR DESCRIPTION
Adds endpoints /songnames which returns JSON of all the song names (minus file extensions), 
and /songfiles which returns JSON of all the song filenames (including extensions).