### PR TITLE
Add headers to fix connection between services

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,8 +85,8 @@ func (r *RootCfg) serveHls() {
 	fs := http.FileServer(http.Dir(dirPath))
 
 	mux.Handle("/", utils.AddHeaders(fs))
-	mux.Handle(songFilesEndpoint, songFilesHandler(marshaledPlaylistFiles))
-	mux.Handle(songNamesEndpoint, songNamesHandler(marshaledSongNames))
+	mux.Handle(songFilesEndpoint, utils.AddHeaders(songFilesHandler(marshaledPlaylistFiles)))
+	mux.Handle(songNamesEndpoint, utils.AddHeaders(songNamesHandler(marshaledSongNames)))
 
 	if debug {
 		r.printFileNames()


### PR DESCRIPTION
- AddHeaders function applied to songnames and songfiles endpoints